### PR TITLE
Stop installer force upgrading all packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,6 @@ if [ $install == 1 ]
 then
 	echo "Installing required packages: $packages"
 	apt-get update
-	apt-get upgrade -y
 	if ! apt-get install -y $packages
 	then
 		echo "Failed to install required packages: $packages"


### PR DESCRIPTION
The `install.sh` script includes the command `apt-get upgrade -y` which force upgrades all packages installed on the system without asking the user for permission or confirmation.  Some users may not wish to upgrade all packages on their system to avoid [issues like this](https://discussions.flightaware.com/t/fyi-new-pi-kernel-causes-dump1090-fa-to-run-much-harder/67309).  This pull request removes that command.